### PR TITLE
記事編集時に本文／追記入力欄が表示されない問題を解消しました。

### DIFF
--- a/cms/soycms/js/editor/RichTextEditor.js
+++ b/cms/soycms/js/editor/RichTextEditor.js
@@ -15,8 +15,6 @@ tinymce.init({
 
 	init_instance_callback : function(editor) {
 		onInitTinymceEditor(editor.id);
-	},
-	oninit : function(){
 		onInitTinymce();
 	},
 


### PR DESCRIPTION
私の環境だけかもしれませんが、標記の問題が発生しました。
- 「記事詳細」画面(Entry/Detail)で、「本文」「追記」を入力する欄(textarea)が表示されない(TinyMCE使用時)。
- 「本文」「追記」のタブは表示されるが、いずれをクリックしても反応がない(「本文」がアクティブのまま)。

スクリプトを追ってみたところ、onInitTinymce()が呼ばれていないようでしたので、その呼び出し元を変更しています(ただしこれがベストな呼び出し元かどうかはわかりません)。
