### PR TITLE
HTMLモジュール一覧のレイアウトが崩れるのを修正しました。

### DIFF
--- a/cms/soycms/webapp/pages/Module/IndexPage.html
+++ b/cms/soycms/webapp/pages/Module/IndexPage.html
@@ -44,8 +44,8 @@
 			</div>
 
 			<div class="row">
+				<!-- soy:id="allow_php_module*" -->
 				<div class="col-lg-6">
-					<!-- soy:id="allow_php_module*" -->
 					<div class="panel panel-green">
 						<div class="panel-heading">
 							モジュール一覧
@@ -84,8 +84,8 @@
 						</div soy:id="has_module">
 					 </div>
 				</div>
+				<!-- /.col-lg-6 -->
 				<!-- /soy:id="allow_php_module*" -->
-				<!-- /.col-lg-12 -->
 
 				<div class="col-lg-6">
 					<div class="panel panel-green">
@@ -126,7 +126,7 @@
 						</div soy:id="has_html_module">
 					</div>
 				</div>
-				<!-- /.col-lg-12 -->
+				<!-- /.col-lg-6 -->
 			</div>
 			<!-- /.row -->
 		</div>


### PR DESCRIPTION
「モジュール管理」ページではレスポンシブなデザインが採用されていますが、画面の幅が広くなる（bodyが1200px以上になる）と「HTMLモジュール一覧」の幅が狭くなり、一覧表の一部しか見えなくなってしまう現象を修正しました。

この現象は、class=col-lg-6 の指定が二重にかかってしまい、幅を50%にしたいところが25%になってしまうことに起因していました。