### PR TITLE
サイト一覧（ダッシュボード）の各サイトのパネルの幅を広げました。

### DIFF
--- a/cms/admin/webapp/pages/IndexPage.html
+++ b/cms/admin/webapp/pages/IndexPage.html
@@ -58,7 +58,7 @@
 								<!-- soy:id="no_site" -->
 									サイトが作成されていないか、ログインできるサイトがありません。
 								<!-- /soy:id="no_site" -->
-								<div class="col-md-3" soy:id="list">
+								<div class="col-lg-4" soy:id="list">
 									<div class="panel panel-default text-nowrap">
 										<div class="panel-heading"  soy:id="site_name">
 											Green Panel


### PR DESCRIPTION
ダッシュボードのサイト一覧の、各サイトのパネル幅が狭すぎる時があるように感じました。 ``col-md-3`` が指定されていますが、最小（Mediumが適用される下限の、画面幅980pxあたり）では130px程度（サイドメニューをたたんでも170px程度）になり、サイトの識別が困難になることがあります。

そこで、サイト一覧（サイト管理？）ページにならって ``col-lg-4`` を指定することで、必要な幅を確保（最小で250px程度）しました。