### PR TITLE
Inquiryのcompleteから戻るリンクの行き先を修正しました。

### DIFF
--- a/cms/app/webapp/inquiry/src/template/bootstrap/complete.php
+++ b/cms/app/webapp/inquiry/src/template/bootstrap/complete.php
@@ -18,5 +18,5 @@
 </div>
 
 <div class="text-center">
-	<a href="/" class="btn btn-primary btn-lg">戻る</a>
+<a href="<?php echo $page_link; ?>" class="btn btn-primary btn-lg">戻る</a>
 </div>

--- a/cms/app/webapp/inquiry/src/template/responsive/complete.php
+++ b/cms/app/webapp/inquiry/src/template/responsive/complete.php
@@ -13,5 +13,5 @@
 	</dl>
 </div>
 <p class="btn">
-<a href="/">戻る</a>
+<a href="<?php echo $page_link; ?>">戻る</a>
 </p>


### PR DESCRIPTION
一部のテンプレートでは href="/" となっていましたが、サイトルートがサブディレクトリの場合に不都合だった（かつ、テンプレートによって変わる必然性がない；更新漏れ？）ので、他のテンプレートと同様に $page_link を使う形に修正しました。